### PR TITLE
Fix: occlusion behind walls & performance boost

### DIFF
--- a/lua/arcana/circles/magic_circle.lua
+++ b/lua/arcana/circles/magic_circle.lua
@@ -397,11 +397,20 @@ function MagicCircleManager:Update()
 	end
 end
 
-function MagicCircleManager:Draw()
+local losTrace = { mask = MASK_OPAQUE }
+local function circleHasBloomLOS(circle)
+	losTrace.start = EyePos()
+	losTrace.endpos = circle.position
+	local tr = util.TraceLine(losTrace)
+
+	return not tr.Hit
+end
+
+function MagicCircleManager:Draw(forBloomPass)
 	for _, circle in ipairs(self.circles) do
 		if circle.Draw then
 			local manual = (circle.IsDrawnManually and circle:IsDrawnManually()) or false
-			if not manual then
+			if not manual and not (forBloomPass and circle.bloomRequiresLOS and not circleHasBloomLOS(circle)) then
 				circle:Draw()
 			end
 		end
@@ -424,15 +433,33 @@ end)
 
 hook.Add("PostDrawTranslucentRenderables", "MagicCircleManager_Draw", function(_, isSkybox)
 	if isSkybox then return end
+	local circles = MagicCircleManager.circles
+	local n = #circles
+	if n == 0 then return end
+
+	local anyBloom = false
+	for i = 1, n do
+		local c = circles[i]
+		local manual = (c.IsDrawnManually and c:IsDrawnManually()) or false
+		if not manual and not (c.bloomRequiresLOS and not circleHasBloomLOS(c)) then
+			anyBloom = true
+			break
+		end
+	end
 
 	local bloom = Arcana.Bloom
-	bloom.ProcessBloom(function()
-		MagicCircleManager:Draw()
-	end)
 
-	MagicCircleManager:Draw()
+	if anyBloom then
+		bloom.ProcessBloom(function()
+			MagicCircleManager:Draw(true)
+		end)
+	end
 
-	bloom.RenderBloom()
+	MagicCircleManager:Draw(false)
+
+	if anyBloom then
+		bloom.RenderBloom()
+	end
 end)
 
 -- Convenience functions (maintaining backward compatibility)

--- a/lua/entities/arcana_portal.lua
+++ b/lua/entities/arcana_portal.lua
@@ -163,6 +163,7 @@ if CLIENT then
 	local circleColor = Color(120, 200, 255, 255)
 
 	function ENT:Initialize()
+		self:SetNoDraw(true)
 		self._circle = nil
 	end
 
@@ -174,10 +175,9 @@ if CLIENT then
 		self._circle = nil
 	end
 
-	local MagicCircle = Arcana.Circle.MagicCircle
-	local MagicCircleManager = Arcana.Circle.MagicCircleManager
-
 	local function ensureCircle(self)
+		local MagicCircle = Arcana.Circle.MagicCircle
+		local MagicCircleManager = Arcana.Circle.MagicCircleManager
 		if not MagicCircle or not MagicCircle.new then return end
 		if self._circle and self._circle.IsActive and self._circle:IsActive() then return end
 		local pos = self:GetPos() + self:GetUp() * 2
@@ -186,6 +186,7 @@ if CLIENT then
 		local size = math.max(80, self:GetRadius() * 1.5)
 		local intensity = 50 -- Higher intensity for more complex circles
 		self._circle = MagicCircle.new(pos, ang, circleColor, intensity, size, 2.5)
+		self._circle.bloomRequiresLOS = true
 		MagicCircleManager:Add(self._circle)
 	end
 


### PR DESCRIPTION
Fixed the bloom being visible behind walls, and increased performance for the:
"PostDrawTranslucentRenderables", "MagicCircleManager_Draw" hook.

originally profiled at ~1.06ms/frame

after improvements:

occluded
] lua_openscript_cl scripts/arcana_profile.lua
Running script scripts/arcana_profile.lua...
[arcana profile] sampling sample for 3s...
[arcana profile] sample  n=1802  avg=0.052ms  p50=0.002ms  p95=0.114ms  max=0.192ms
[arcana profile] total 94.30ms over 3.0s

in view
] lua_openscript_cl scripts/arcana_profile.lua
Running script scripts/arcana_profile.lua...
[arcana profile] sampling sample for 3s...
[arcana profile] sample  n=1812  avg=0.223ms  p50=0.002ms  p95=0.464ms  max=0.571ms
[arcana profile] total 404.30ms over 3.0s