### PR TITLE
Fix: The timer overlapping long text

### DIFF
--- a/lua/arcana/system/hud.lua
+++ b/lua/arcana/system/hud.lua
@@ -298,6 +298,13 @@ local function drawCooldownStack(scrW, scrH)
 	table.sort(entries, function(a, b) return a.remain < b.remain end)
 	local rowW, rowH = 260, 36
 	local gap = 8
+	
+	for i = 1, #entries do 
+		surface.SetFont("Arcana_Ancient")
+		local w = surface.GetTextSize(entries[i].spell.name) + 90
+		if w > rowW then rowW = w end
+	end
+	
 	local totalH = (#entries * rowH) + ((#entries - 1) * gap)
 	local cy = math.floor(scrH * 0.5)
 	local startY = cy - math.floor(totalH * 0.5)

--- a/lua/arcana/system/hud.lua
+++ b/lua/arcana/system/hud.lua
@@ -299,8 +299,8 @@ local function drawCooldownStack(scrW, scrH)
 	local rowW, rowH = 260, 36
 	local gap = 8
 	
+	surface.SetFont("Arcana_Ancient")
 	for i = 1, #entries do 
-		surface.SetFont("Arcana_Ancient")
 		local w = surface.GetTextSize(entries[i].spell.name) + 90
 		if w > rowW then rowW = w end
 	end


### PR DESCRIPTION
Before:
<img width="301" height="73" alt="image 1" src="https://github.com/user-attachments/assets/f27d914c-d65f-47f4-b9e6-f21437ba4a53" />

After:
<img width="387" height="107" alt="image 1" src="https://github.com/user-attachments/assets/da19362a-29d2-412b-9a2a-a7683a9136eb" />
